### PR TITLE
Fix Iteration Bug in Raytracer Pseudocode

### DIFF
--- a/docs/source/PA1.rst
+++ b/docs/source/PA1.rst
@@ -116,7 +116,7 @@ would look something like this:
 ::
 
   for x in image_width:
-    for y in image_width:
+    for y in image_height:
       create ray through pixel (x, y)
       get color and display color on pixel (x, y)
   


### PR DESCRIPTION
#### Description:
This PR corrects an error in the pseudocode where the inner loop mistakenly iterated over `image_width` instead of `image_height`. 

#### Changes:
- Replaced `image_width` with `image_height` in the inner loop of the pseudocode.
